### PR TITLE
Adds support for holes in translation values

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ json file is a simple dictionary of i18n keys and values, for example:
 
 ``` json
 {
+    "Hello": "Hej, {0}. Leder du efter {1}?"
     "Next" : "Næste",
     "No": "Nej",
     "Previous": "Forrige",
@@ -50,6 +51,7 @@ If we supply `i18n2elm` with the folder `examples/input-i18n-json`, containing
 the two JSON files, `da_DK.json`:
 ``` json
 {
+    "Hello": "Hello, {0}. Is it {1} you are looking for?"
     "Next" : "Næste",
     "No": "Nej",
     "Previous": "Forrige",
@@ -79,6 +81,9 @@ import Translations.Ids exposing (TranslationId(..))
 daDkTranslations : TranslationId -> String
 daDkTranslations tid =
     case tid of
+        TidHello hole0 hole1 ->
+            "Hej, " ++ hole0 ++ ". Leder du efter " ++ hole1 ++ "?"
+
         TidNext ->
             "Næste"
 
@@ -103,6 +108,9 @@ import Translations.Ids exposing (TranslationId(..))
 enUsTranslations : TranslationId -> String
 enUsTranslations tid =
     case tid of
+        TidHello hole0 hole1 ->
+            "Hello, " ++ hole0 ++ ". Is it " ++ hole1 ++ " you are looking for?"
+
         TidNext ->
             "Next"
 
@@ -123,7 +131,8 @@ module Translations.Ids exposing (TranslationId(..))
 
 
 type TranslationId
-    = TidNext
+    = TidHello String String
+    | TidNext
     | TidNo
     | TidPrevious
     | TidYes
@@ -135,23 +144,23 @@ and finally `Translations/Util.elm`:
 module Translations.Util exposing (parseLanguage, translate, LanguageTag(..))
 
 import Translations.Ids exposing (TranslationId)
-import Translations.EnUs exposing (enUsTranslations)
 import Translations.DaDk exposing (daDkTranslations)
+import Translations.EnUs exposing (enUsTranslations)
 
 
 type LanguageTag
-    = EN_US
-    | DA_DK
+    = DA_DK
+    | EN_US
 
 
 parseLanguage : String -> LanguageTag
 parseLanguage tag =
     case tag of
-        "en_US" ->
-            EN_US
-
         "da_DK" ->
             DA_DK
+
+        "en_US" ->
+            EN_US
 
         _ ->
             Debug.log
@@ -164,11 +173,11 @@ translate languageTag translationId =
     let
         translateFun =
             case languageTag of
-                EN_US ->
-                    enUsTranslations
-
                 DA_DK ->
                     daDkTranslations
+
+                EN_US ->
+                    enUsTranslations
     in
         translateFun translationId
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ json file is a simple dictionary of i18n keys and values, for example:
 
 ``` json
 {
-    "Hello": "Hej, {0}. Leder du efter {1}?"
+    "Hello": "Hej, {0}. Leder du efter {1}?",
     "Next" : "Næste",
     "No": "Nej",
     "Previous": "Forrige",
@@ -51,7 +51,7 @@ If we supply `i18n2elm` with the folder `examples/input-i18n-json`, containing
 the two JSON files, `da_DK.json`:
 ``` json
 {
-    "Hello": "Hello, {0}. Is it {1} you are looking for?"
+    "Hello": "Hello, {0}. Is it {1} you are looking for?",
     "Next" : "Næste",
     "No": "Nej",
     "Previous": "Forrige",

--- a/examples/input-i18n-json/da_DK.json
+++ b/examples/input-i18n-json/da_DK.json
@@ -2,5 +2,6 @@
     "Next" : "Næste",
     "No": "Nej",
     "Previous": "Forrige",
-    "Yes": "Ja"
+    "Yes": "Ja",
+    "Hello": "Hej, {0}. Leder du efter {1}?"
 }

--- a/examples/input-i18n-json/en_US.json
+++ b/examples/input-i18n-json/en_US.json
@@ -2,5 +2,6 @@
     "Next" : "Next",
     "No": "No",
     "Previous": "Previous",
-    "Yes": "Yes"
+    "Yes": "Yes",
+    "Hello": "Hello, {0}. Is it {1} you are looking for?"
 }

--- a/examples/output-elm-code/Translations/DaDk.elm
+++ b/examples/output-elm-code/Translations/DaDk.elm
@@ -6,6 +6,9 @@ import Translations.Ids exposing (TranslationId(..))
 daDkTranslations : TranslationId -> String
 daDkTranslations tid =
     case tid of
+        TidHello hole0 hole1 ->
+            "Hej, " ++ hole0 ++ ". Leder du efter " ++ hole1 ++ "?"
+
         TidNext ->
             "Næste"
 

--- a/examples/output-elm-code/Translations/EnUs.elm
+++ b/examples/output-elm-code/Translations/EnUs.elm
@@ -6,6 +6,9 @@ import Translations.Ids exposing (TranslationId(..))
 enUsTranslations : TranslationId -> String
 enUsTranslations tid =
     case tid of
+        TidHello hole0 hole1 ->
+            "Hello, " ++ hole0 ++ ". Is it " ++ hole1 ++ " you are looking for?"
+
         TidNext ->
             "Next"
 

--- a/examples/output-elm-code/Translations/Ids.elm
+++ b/examples/output-elm-code/Translations/Ids.elm
@@ -2,7 +2,8 @@ module Translations.Ids exposing (TranslationId(..))
 
 
 type TranslationId
-    = TidNext
+    = TidHello String String
+    | TidNext
     | TidNo
     | TidPrevious
     | TidYes

--- a/examples/output-elm-code/Translations/Util.elm
+++ b/examples/output-elm-code/Translations/Util.elm
@@ -1,23 +1,23 @@
 module Translations.Util exposing (parseLanguage, translate, LanguageTag(..))
 
 import Translations.Ids exposing (TranslationId)
-import Translations.EnUs exposing (enUsTranslations)
 import Translations.DaDk exposing (daDkTranslations)
+import Translations.EnUs exposing (enUsTranslations)
 
 
 type LanguageTag
-    = EN_US
-    | DA_DK
+    = DA_DK
+    | EN_US
 
 
 parseLanguage : String -> LanguageTag
 parseLanguage tag =
     case tag of
-        "en_US" ->
-            EN_US
-
         "da_DK" ->
             DA_DK
+
+        "en_US" ->
+            EN_US
 
         _ ->
             Debug.log
@@ -30,10 +30,10 @@ translate languageTag translationId =
     let
         translateFun =
             case languageTag of
-                EN_US ->
-                    enUsTranslations
-
                 DA_DK ->
                     daDkTranslations
+
+                EN_US ->
+                    enUsTranslations
     in
         translateFun translationId

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -23,15 +23,63 @@ defmodule I18n2Elm.Parser do
     |> parse_translation(language_tag)
   end
 
+  @doc ~S"""
+  Parses a map of translations into a `Translation` struct.
+
+  ## Examples
+
+      iex> translation = %{"Yes" => "Ja",
+      ...>                 "No" => "Nej",
+      ...>                 "Next" => "Næste",
+      ...>                 "Previous" => "Forrige",
+      ...>                 "Hello" => "Hej, {0}. Leder du efter {1}?"}
+      iex> parse_translation(translation, "da_DK")
+      %I18n2Elm.Types.Translation{
+          language_tag: "da_DK",
+          translations: [
+              {"TidHello", [{"Hej, ", 0},
+                            {". Leder du efter ", 1},
+                            {"?"}]},
+              {"TidNext", [{"Næste"}]},
+              {"TidNo", [{"Nej"}]},
+              {"TidPrevious", [{"Forrige"}]},
+              {"TidYes", [{"Ja"}]}
+      ]}
+  """
   @spec parse_translation(map, String.t) :: Translation.t
   def parse_translation(translation_node, language_tag) do
     translations =
       translation_node
       |> Enum.to_list
       |> Enum.sort
+      |> Enum.map(&check_for_holes/1)
       |> Enum.map(fn {key, value} -> {"Tid#{key}", value} end)
 
     Translation.new(language_tag, translations)
   end
+
+  defp check_for_holes({key, text}) do
+    text_with_holes =
+      text
+      |> split
+      |> group
+      |> Enum.map(&tuplify/1)
+      |> Enum.map(&hole_to_number/1)
+
+    {key, text_with_holes}
+  end
+
+  defp split(str), do: str |> String.split(~r/\{|\}/)
+
+  defp group(lst), do: lst |> Enum.chunk_every(2)
+
+  defp tuplify(lst), do: lst |> List.to_tuple
+
+  defp hole_to_number({text, hole}) do
+    {text}
+    |> Tuple.append(hole |> Integer.parse |> elem(0))
+  end
+  defp hole_to_number({text}), do: {text}
+
 
 end

--- a/lib/types.ex
+++ b/lib/types.ex
@@ -15,17 +15,21 @@ defmodule I18n2Elm.Types do
             "Yes": "Ja",
             "No": "Nej",
             "Next": "Næste",
-            "Previous": "Forrige"
+            "Previous": "Forrige",
+            "Hello": "Hej, {0}. Leder du efter {1}?"
         }
 
     Elixir representation:
 
         %Translation{language_tag: "da_DK",
                      translations: [
-                         {"Yes", "Ja"},
-                         {"No", "Nej"},
-                         {"Next", "Næste"},
-                         {"Previous", "Forrige"}
+                         {"TidHello", [{"Hej, ", 0},
+                                       {". Leder du efter ", 1},
+                                       {"?"}]},
+                         {"TidNext", [{"Næste"}]},
+                         {"TidNo", [{"Nej"}]},
+                         {"TidPrevious", [{"Forrige"}]}
+                         {"TidYes", [{"Ja"}]},
                      ]}
 
     Elm code generated:
@@ -37,6 +41,9 @@ defmodule I18n2Elm.Types do
     daDkTranslations : TranslationId -> String
     daDkTranslations tid =
         case tid of
+            TidHello hole0 hole1 ->
+                "Hej, " ++ hole0 ++ ". Leder du efter " ++ hole1 ++ "?"
+
             TidYes ->
                 "Ja"
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule I18n2Elm.Mixfile do
   def project do
     [app: :i18n2elm,
      version: "0.1.0",
-     elixir: "~> 1.4",
+     elixir: "~> 1.5",
      deps: deps(),
      aliases: aliases(),
      build_embedded: Mix.env == :prod,

--- a/priv/templates/language.elm.eex
+++ b/priv/templates/language.elm.eex
@@ -8,5 +8,5 @@ import <%= module_name %>.Ids exposing (TranslationId(..))
     case tid of<%#
     %><%= for {key, value} <- translations do %>
         <%= key %> ->
-            "<%= value %>"
+            <%= value %>
 <% end %>

--- a/test/e2e_test.exs
+++ b/test/e2e_test.exs
@@ -11,20 +11,26 @@ defmodule I18n2ElmTest.E2E do
       %Translation{
         language_tag: "da_DK",
         translations: [
-          {"TidNext", "Næste"},
-          {"TidNo", "Nej"},
-          {"TidPrevious", "Forrige"},
-          {"TidYes", "Ja"}
+          {"TidHello", [{"Hej, ", 1},
+                        {". Leder du efter ", 0},
+                        {"?"}]},
+          {"TidNext", [{"Næste"}]},
+          {"TidNo", [{"Nej"}]},
+          {"TidPrevious", [{"Forrige"}]},
+          {"TidYes", [{"Ja"}]}
         ]
       },
 
       %Translation{
         language_tag: "en_US",
         translations: [
-          {"TidNext", "Next"},
-          {"TidNo", "No"},
-          {"TidPrevious", "Previous"},
-          {"TidYes", "Yes"}
+          {"TidHello", [{"Hello, ", 0},
+                        {"It is ", 1},
+                        {"you are looking for?"}]},
+          {"TidNext", [{"Next"}]},
+          {"TidNo", [{"No"}]},
+          {"TidPrevious", [{"Previous"}]},
+          {"TidYes", [{"Yes"}]}
         ]
       }
     ]

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -1,5 +1,7 @@
 defmodule I18n2ElmTest.Parser do
   use ExUnit.Case
+  doctest I18n2Elm.Parser, import: true
+
   alias I18n2Elm.Parser
   alias I18n2Elm.Types.Translation
 
@@ -11,7 +13,8 @@ defmodule I18n2ElmTest.Parser do
         "Yes": "Ja",
         "No": "Nej",
         "Next": "Næste",
-        "Previous": "Forrige"
+        "Previous": "Forrige",
+        "Hello": "Hej, {0}. Leder du efter {1}?"
       }
       """
       |> Poison.decode!()
@@ -20,10 +23,13 @@ defmodule I18n2ElmTest.Parser do
     expected_parsed_translation = %Translation{
       language_tag: "da_DK",
       translations: [
-        {"TidNext", "Næste"},
-        {"TidNo", "Nej"},
-        {"TidPrevious", "Forrige"},
-        {"TidYes", "Ja"}
+        {"TidHello", [{"Hej, ", 0},
+                      {". Leder du efter ", 1},
+                      {"?"}]},
+        {"TidNext", [{"Næste"}]},
+        {"TidNo", [{"Nej"}]},
+        {"TidPrevious", [{"Forrige"}]},
+        {"TidYes", [{"Ja"}]}
       ]
     }
 

--- a/test/printer_test.exs
+++ b/test/printer_test.exs
@@ -1,6 +1,7 @@
 defmodule I18n2ElmTest.Printer do
-
   use ExUnit.Case
+  doctest I18n2Elm.Printer, import: true
+
   alias I18n2Elm.Printer
   alias I18n2Elm.Types.Translation
 
@@ -10,10 +11,13 @@ defmodule I18n2ElmTest.Printer do
       %Translation{
         language_tag: "da_DK",
         translations: [
-          {"TidNext", "Næste"},
-          {"TidNo", "Nej"},
-          {"TidPrevious", "Forrige"},
-          {"TidYes", "Ja"}
+          {"TidHello", [{"Hej, ", 1},
+                        {". Leder du efter ", 0},
+                        {"?"}]},
+          {"TidNext", [{"Næste"}]},
+          {"TidNo", [{"Nej"}]},
+          {"TidPrevious", [{"Forrige"}]},
+          {"TidYes", [{"Ja"}]}
         ]
       }
       |> Printer.print_translation("Translations")
@@ -27,6 +31,9 @@ defmodule I18n2ElmTest.Printer do
     daDkTranslations : TranslationId -> String
     daDkTranslations tid =
         case tid of
+            TidHello hole0 hole1 ->
+                "Hej, " ++ hole1 ++ ". Leder du efter " ++ hole0 ++ "?"
+
             TidNext ->
                 "Næste"
 
@@ -38,7 +45,6 @@ defmodule I18n2ElmTest.Printer do
 
             TidYes ->
                 "Ja"
-
     """
 
     assert translations_file_path == "./Translations/DaDk.elm"
@@ -51,20 +57,26 @@ defmodule I18n2ElmTest.Printer do
       %Translation{
         language_tag: "da_DK",
         translations: [
-          {"TidNext", "Næste"},
-          {"TidNo", "Nej"},
-          {"TidPrevious", "Forrige"},
-          {"TidYes", "Ja"}
+          {"TidHello", [{"Hej, ", 0},
+                        {". Leder du efter ", 1},
+                        {"?"}]},
+          {"TidNext", [{"Næste"}]},
+          {"TidNo", [{"Nej"}]},
+          {"TidPrevious", [{"Forrige"}]},
+          {"TidYes", [{"Ja"}]}
         ]
       },
 
       %Translation{
         language_tag: "en_US",
         translations: [
-          {"TidNext", "Next"},
-          {"TidNo", "No"},
-          {"TidPrevious", "Previous"},
-          {"TidYes", "Yes"}
+          {"TidHello", [{"Hello, ", 0},
+                        {"It is ", 1},
+                        {"you are looking for?"}]},
+          {"TidNext", [{"Next"}]},
+          {"TidNo", [{"No"}]},
+          {"TidPrevious", [{"Previous"}]},
+          {"TidYes", [{"Yes"}]}
         ]
       }
     ]
@@ -76,7 +88,8 @@ defmodule I18n2ElmTest.Printer do
 
 
     type TranslationId
-        = TidNext
+        = TidHello String String
+        | TidNext
         | TidNo
         | TidPrevious
         | TidYes
@@ -92,20 +105,26 @@ defmodule I18n2ElmTest.Printer do
       %Translation{
         language_tag: "da_DK",
         translations: [
-          {"TidNext", "Næste"},
-          {"TidNo", "Nej"},
-          {"TidPrevious", "Forrige"},
-          {"TidYes", "Ja"}
+          {"TidHello", [{"Hej, ", 0},
+                        {". Leder du efter ", 1},
+                        {"?"}]},
+          {"TidNext", [{"Næste"}]},
+          {"TidNo", [{"Nej"}]},
+          {"TidPrevious", [{"Forrige"}]},
+          {"TidYes", [{"Ja"}]}
         ]
       },
 
       %Translation{
         language_tag: "en_US",
         translations: [
-          {"TidNext", "Next"},
-          {"TidNo", "No"},
-          {"TidPrevious", "Previous"},
-          {"TidYes", "Yes"}
+          {"TidHello", [{"Hello, ", 0},
+                        {"It is ", 1},
+                        {"you are looking for?"}]},
+          {"TidNext", [{"Next"}]},
+          {"TidNo", [{"No"}]},
+          {"TidPrevious", [{"Previous"}]},
+          {"TidYes", [{"Yes"}]}
         ]
       }
     ]


### PR DESCRIPTION
It is now possible to add a hole in a translation like so

    "HelloYou": "Hello, {0}"

and then call

    translate EN_US (TidHelloYou "World")
    -- ==> "Hello, World"

with the hole filled with `"World"`.